### PR TITLE
Custom center

### DIFF
--- a/src/actions/job.ts
+++ b/src/actions/job.ts
@@ -56,10 +56,7 @@ export const runJob = (configuration: any) => {
       model: year === '1961_1990' || year === '1981_2010' ? undefined : selectedClimate.model,
       variables: variables.map((item: any) => {
         const { name, transfer, customCenter } = item
-        let { value } = item
-        if (customMode) {
-          value = customCenter
-        }
+        const value = customMode ? customCenter : item.value
         return {
           name,
           limit: { min: value - transfer, max: value + transfer },

--- a/src/actions/job.ts
+++ b/src/actions/job.ts
@@ -42,7 +42,7 @@ export const runJob = (configuration: any) => {
   const { functions, constraints: constraintsConfig } = config
 
   return (dispatch: (action: any) => any) => {
-    const { variables, traits, objective, climate, region, constraints, userSites } = configuration
+    const { variables, traits, objective, climate, region, constraints, userSites, customMode } = configuration
 
     /* Run the tool against the seedlot climate when looking for seedlots, otherwise run against the
      * planting site climate.
@@ -55,7 +55,11 @@ export const runJob = (configuration: any) => {
       year: selectedClimate.time,
       model: year === '1961_1990' || year === '1981_2010' ? undefined : selectedClimate.model,
       variables: variables.map((item: any) => {
-        const { name, value, transfer } = item
+        const { name, transfer, customCenter } = item
+        let { value } = item
+        if (customMode) {
+          value = customCenter
+        }
         return {
           name,
           limit: { min: value - transfer, max: value + transfer },

--- a/src/actions/variables.ts
+++ b/src/actions/variables.ts
@@ -62,7 +62,7 @@ export const removeVariable = (variable: string, index: number) => {
   }
 }
 
-export const modifyVariable = (variable: string, modifications: { transfer?: number; value?: number }) => {
+export const modifyVariable = (variable: string, modifications: { transfer?: number; customCenter?: number }) => {
   return {
     type: MODIFY_VARIABLE,
     variable,

--- a/src/actions/variables.ts
+++ b/src/actions/variables.ts
@@ -12,6 +12,7 @@ export const RECEIVE_TRANSFER = 'RECEIVE_TRANSFER'
 export const REQUEST_TRANSFER = 'REQUEST_TRANSFER'
 export const SET_VARIABLES_REGION = 'SET_VARIABLES_REGION'
 export const SET_DEFAULT_VARIABLES = 'SET_DEFAULT_VARIABLES'
+export const SET_CUSTOM_MODE = 'SET_CUSTOM_MODE'
 
 export const selectUnit = (unit: string) => {
   return {
@@ -61,11 +62,11 @@ export const removeVariable = (variable: string, index: number) => {
   }
 }
 
-export const modifyVariable = (variable: string, transfer: number) => {
+export const modifyVariable = (variable: string, modifications: { transfer?: number; value?: number }) => {
   return {
     type: MODIFY_VARIABLE,
     variable,
-    transfer,
+    modifications,
   }
 }
 
@@ -129,5 +130,12 @@ export const setDefaultVariables = (useDefault: boolean) => {
   return {
     type: SET_DEFAULT_VARIABLES,
     useDefault,
+  }
+}
+
+export const setCustomMode = (customMode: boolean) => {
+  return {
+    type: SET_CUSTOM_MODE,
+    customMode,
   }
 }

--- a/src/async/variables.ts
+++ b/src/async/variables.ts
@@ -26,7 +26,7 @@ const transferSelect = ({ runConfiguration }: any) => {
 
 const valueSelect = ({ runConfiguration }: any) => {
   let { point } = runConfiguration
-  const { objective, climate, variables, validRegions, customMode } = runConfiguration
+  const { objective, climate, variables, validRegions } = runConfiguration
 
   if (point) {
     point = { x: point.x, y: point.y }
@@ -38,7 +38,6 @@ const valueSelect = ({ runConfiguration }: any) => {
     climate,
     variables: variables.map((item: any) => item.name),
     validRegions,
-    customMode
   }
 }
 
@@ -184,9 +183,9 @@ export default (store: any) => {
 
   // Values at point (for variables list)
   resync(store, valueSelect, (state, io, dispatch, previousState) => {
-    const { validRegions, customMode } = state
+    const { validRegions } = state
 
-    if (validRegions.length && !customMode) {
+    if (validRegions.length) {
       const requests = fetchValues(store, state, io, dispatch, previousState, validRegions[0])
 
       requests.forEach((request: any) => {

--- a/src/async/variables.ts
+++ b/src/async/variables.ts
@@ -26,7 +26,7 @@ const transferSelect = ({ runConfiguration }: any) => {
 
 const valueSelect = ({ runConfiguration }: any) => {
   let { point } = runConfiguration
-  const { objective, climate, variables, validRegions } = runConfiguration
+  const { objective, climate, variables, validRegions, customMode } = runConfiguration
 
   if (point) {
     point = { x: point.x, y: point.y }
@@ -38,6 +38,7 @@ const valueSelect = ({ runConfiguration }: any) => {
     climate,
     variables: variables.map((item: any) => item.name),
     validRegions,
+    customMode
   }
 }
 
@@ -183,9 +184,9 @@ export default (store: any) => {
 
   // Values at point (for variables list)
   resync(store, valueSelect, (state, io, dispatch, previousState) => {
-    const { validRegions } = state
+    const { validRegions, customMode } = state
 
-    if (validRegions.length) {
+    if (validRegions.length && !customMode) {
       const requests = fetchValues(store, state, io, dispatch, previousState, validRegions[0])
 
       requests.forEach((request: any) => {

--- a/src/containers/RunStep.tsx
+++ b/src/containers/RunStep.tsx
@@ -51,7 +51,7 @@ const connector = connect(
   },
   (dispatch: (event: any) => any) => ({
     onRun: (configuration: any) => {
-      const { variables, constraints } = configuration
+      const { variables, constraints, customMode } = configuration
 
       if (variables.some((item: any) => item.transfer === null)) {
         dispatch(
@@ -61,6 +61,19 @@ const connector = connect(
           ),
         )
         return
+      }
+
+      if (customMode) {
+        if (variables.some((item: any) => item.customCenter === null)) {
+          dispatch(
+            setError(
+              t`Configuration error`,
+              t`Cannot calculate scores: Custom center is enabled and one or more of your variables has no custom 
+              center.`,
+            ),
+          )
+          return
+        }
       }
 
       if (constraints.some((item: any) => Object.keys(item.values).some(key => item.values[key] === null))) {

--- a/src/containers/RunStep.tsx
+++ b/src/containers/RunStep.tsx
@@ -12,8 +12,22 @@ import { showSaveModal } from '../actions/saves'
 import { createReport, runTIFJob } from '../actions/report'
 import { reports } from '../config'
 
-const configurationCanRun = ({ point, variables, traits }: { point: any; variables: any[]; traits: any[] }) => {
+const configurationCanRun = ({
+  point,
+  variables,
+  traits,
+  customMode,
+}: {
+  point: any
+  variables: any[]
+  traits: any[]
+  customMode: boolean
+}) => {
   if (point === null || point.x === null || point.y === null) {
+    return false
+  }
+
+  if (customMode && variables.length > 0 && variables.some(item => item.customCenter === null)) {
     return false
   }
 
@@ -51,7 +65,7 @@ const connector = connect(
   },
   (dispatch: (event: any) => any) => ({
     onRun: (configuration: any) => {
-      const { variables, constraints, customMode } = configuration
+      const { variables, constraints } = configuration
 
       if (variables.some((item: any) => item.transfer === null)) {
         dispatch(
@@ -61,19 +75,6 @@ const connector = connect(
           ),
         )
         return
-      }
-
-      if (customMode) {
-        if (variables.some((item: any) => item.customCenter === null)) {
-          dispatch(
-            setError(
-              t`Configuration error`,
-              t`Cannot calculate scores: Custom center is enabled and one or more of your variables has no custom 
-              center.`,
-            ),
-          )
-          return
-        }
       }
 
       if (constraints.some((item: any) => Object.keys(item.values).some(key => item.values[key] === null))) {

--- a/src/containers/VariableStep.tsx
+++ b/src/containers/VariableStep.tsx
@@ -79,15 +79,15 @@ const VariableStep = ({
 
       <div className="margin-bottom-10">
         <input
-          className="is-checkradio is-rtl is-info"
+          className="is-checkradio is-info"
           id="customMode"
           type="checkbox"
           name="customMode"
           checked={customMode}
           onChange={() => onCustomModeChange(!customMode)}
         />
-        <label htmlFor="customMode" className="ml-0">
-          <strong>{t`Custom center`} </strong>(advanced users)<strong>:</strong>
+        <label htmlFor="customMode">
+          <strong>{t`Custom climate values`} </strong>(advanced users)<strong>:</strong>
         </label>
       </div>
 

--- a/src/containers/VariableStep.tsx
+++ b/src/containers/VariableStep.tsx
@@ -5,13 +5,13 @@ import ConfigurationStep from './ConfigurationStep'
 import UnitButton from './UnitButton'
 import Variables from './Variables'
 import config from '../config'
-import { addVariables, setDefaultVariables } from '../actions/variables'
+import { addVariables, setCustomMode, setDefaultVariables } from '../actions/variables'
 
 const connector = connect(
   ({ runConfiguration }: { runConfiguration: any }) => {
-    const { variables, method } = runConfiguration
+    const { variables, method, customMode } = runConfiguration
 
-    return { variables, method }
+    return { variables, method, customMode }
   },
   dispatch => ({
     setDefaultVariables: () => {
@@ -19,6 +19,9 @@ const connector = connect(
 
       dispatch(addVariables(defaultVariables.map(({ variable }) => variable)))
       dispatch(setDefaultVariables(true))
+    },
+    onCustomModeChange: (customMode: boolean) => {
+      dispatch(setCustomMode(customMode))
     },
   }),
 )
@@ -28,7 +31,15 @@ type VariableStepProps = ConnectedProps<typeof connector> & {
   active: boolean
 }
 
-const VariableStep = ({ number, active, variables, method, setDefaultVariables }: VariableStepProps) => {
+const VariableStep = ({
+  number,
+  active,
+  variables,
+  method,
+  customMode,
+  onCustomModeChange,
+  setDefaultVariables,
+}: VariableStepProps) => {
   if (method === 'function') {
     return null
   }
@@ -64,6 +75,20 @@ const VariableStep = ({ number, active, variables, method, setDefaultVariables }
             <UnitButton name="imperial">{t`Imperial`}</UnitButton>
           </ul>
         </div>
+      </div>
+
+      <div className="margin-bottom-10">
+        <input
+          className="is-checkradio is-rtl is-info"
+          id="customMode"
+          type="checkbox"
+          name="customMode"
+          checked={customMode}
+          onChange={() => onCustomModeChange(!customMode)}
+        />
+        <label htmlFor="customMode" className="ml-0">
+          <strong>{t`Custom center`} </strong>(advanced users)<strong>:</strong>
+        </label>
       </div>
 
       <Variables edit />

--- a/src/reducers/runConfiguration.ts
+++ b/src/reducers/runConfiguration.ts
@@ -19,7 +19,14 @@ import {
   SET_ACTIVE_USER_SITE,
 } from '../actions/point'
 import { SELECT_SPECIES, RECEIVE_AVAILABLE_SPECIES } from '../actions/species'
-import { SELECT_UNIT, SELECT_METHOD, SELECT_CENTER, REMOVE_VARIABLE, SET_DEFAULT_VARIABLES } from '../actions/variables'
+import {
+  SELECT_UNIT,
+  SELECT_METHOD,
+  SELECT_CENTER,
+  REMOVE_VARIABLE,
+  SET_DEFAULT_VARIABLES,
+  SET_CUSTOM_MODE,
+} from '../actions/variables'
 import { LOAD_CONFIGURATION, RESET_CONFIGURATION } from '../actions/saves'
 import { FINISH_JOB } from '../actions/job'
 import { SELECT_STEP } from '../actions/step'
@@ -55,6 +62,7 @@ const defaultConfiguration = {
   activeUserSite: null,
   uploadedPoints: null,
   customLayers: [],
+  customMode: false,
 }
 
 export default (state: any = defaultConfiguration, action: any) => {
@@ -182,6 +190,12 @@ export default (state: any = defaultConfiguration, action: any) => {
       case LOAD_CONFIGURATION:
         return { ...defaultConfiguration, ...action.configuration }
 
+      case SET_CUSTOM_MODE:
+        return {
+          ...state,
+          customMode: action.customMode,
+        }
+
       default:
         return state
     }
@@ -196,7 +210,7 @@ export default (state: any = defaultConfiguration, action: any) => {
     zones: zones(newState.zones || undefined, action),
     climate: climate(newState.climate || undefined, action),
     constraints: constraints(newState.constraints, action),
-    customLayers: customLayers(newState.customLayers, action)
+    customLayers: customLayers(newState.customLayers, action),
   }
 }
 

--- a/src/reducers/variables.ts
+++ b/src/reducers/variables.ts
@@ -52,8 +52,18 @@ export default (state: any = [], action: any) => {
     case REMOVE_VARIABLE:
       return state.slice(0, action.index).concat(state.slice(action.index + 1))
 
-    case MODIFY_VARIABLE:
-      return updateVariable(action.variable, { transfer: action.transfer, transferIsModified: true })
+    case MODIFY_VARIABLE: {
+      const { transfer, value } = action.modifications
+      const modifications = {} as any
+      if (transfer !== undefined) {
+        modifications.transfer = transfer
+        modifications.transferIsModified = true
+      }
+      if (value !== undefined) {
+        modifications.value = value
+      }
+      return updateVariable(action.variable, modifications)
+    }
 
     case RESET_TRANSFER:
       variable = getVariable(action.variable)

--- a/src/reducers/variables.ts
+++ b/src/reducers/variables.ts
@@ -46,6 +46,7 @@ export default (state: any = [], action: any) => {
           transferIsModified: false,
           isFetching: false,
           isFetchingTransfer: false,
+          customCenter: null,
         })),
       ]
 
@@ -53,14 +54,14 @@ export default (state: any = [], action: any) => {
       return state.slice(0, action.index).concat(state.slice(action.index + 1))
 
     case MODIFY_VARIABLE: {
-      const { transfer, value } = action.modifications
+      const { transfer, customCenter } = action.modifications
       const modifications = {} as any
       if (transfer !== undefined) {
         modifications.transfer = transfer
         modifications.transferIsModified = true
       }
-      if (value !== undefined) {
-        modifications.value = value
+      if (customCenter !== undefined) {
+        modifications.customCenter = customCenter
       }
       return updateVariable(action.variable, modifications)
     }


### PR DESCRIPTION
Adds optional custom mode checkbox to the variables step. Selecting custom mode allows the user to edit a variable's center value, storing it as `customCenter`. When the tool is run, if custom mode is enabled, `centerValue` is substituted for `value` before being sent to the backend.

Known uncertainties:
`customMode` is saved to the run configuration, which is sent to the backend but not used. I'm not sure if I should instead save it elsewhere or delete it before sending it to the backend.

`modifyVariable()` has been updated to accept `modifications: { transfer?: number; customCenter?: number }` as a second argument instead of `transfer`. An alternative would be to create `setCustomCenter()` and leave `modifyVariable()` alone.