### PR TITLE
Full height compare

### DIFF
--- a/src/containers/Comparisons.tsx
+++ b/src/containers/Comparisons.tsx
@@ -51,7 +51,9 @@ const Comparisons = ({
   onMouseOverSite,
   onSetMapMode,
 }: ComparisonsProps) => {
-  const [active, setActive] = React.useState(false)
+  const [expandLevel, setExpandLevel] = React.useState(0)
+  const expandClasses = ['', 'preview', 'full-height']
+  const expandMessages = [t`Click to show`, t`Click for full height`, t`Click to hide`]
   const [newSite, setNewSite] = React.useState({ lat: '', lon: '', label: '' })
   const [activeEdit, setActiveEdit] = React.useState(null as { lat: number; lon: number; label: string } | null)
   const [processingCSV, setProcessingCSV] = React.useState(false)
@@ -64,7 +66,7 @@ const Comparisons = ({
   }
 
   return (
-    <div className={`comparisons ${active ? 'active' : ''}`}>
+    <div className={`comparisons ${expandClasses[expandLevel]}`}>
       <input
         type="file"
         className="is-hidden"
@@ -131,9 +133,20 @@ const Comparisons = ({
           }
         }}
       />
-      <button type="button" className="expand-button" onClick={() => setActive(!active)}>
+      <button type="button" className="expand-button" onClick={() => setExpandLevel((expandLevel + 1) % 3)}>
         <div>{objective === 'seedlots' ? t`Compare Seedlots` : t`Compare Planting Sites`}</div>
-        <div className="expand-message">{active ? t`Click to hide` : t`Click to show`}</div>
+        <div className="expand-message">{expandMessages[expandLevel]}</div>
+        <div className="expand-icons">
+          {expandClasses.map((className, idx) => (
+            <div
+              className={`expand-icon ${className} ${expandLevel === idx ? 'active' : ''}`}
+              onClick={e => {
+                e.stopPropagation()
+                setExpandLevel(idx)
+              }}
+            />
+          ))}
+        </div>
       </button>
       <div className="scroll-table">
         <table className="table is-hoverable">

--- a/style/seedsource.scss
+++ b/style/seedsource.scss
@@ -601,7 +601,11 @@ tr.visible .visibility-toggle, .visibility-toggle:hover {
           }
 
           &.active {
-            outline: 1px dashed gold;
+            outline: 1px dashed orange;
+          }
+
+          &:hover {
+            outline: 1px solid orange;
           }
         }
       }

--- a/style/seedsource.scss
+++ b/style/seedsource.scss
@@ -555,7 +555,7 @@ tr.visible .visibility-toggle, .visibility-toggle:hover {
     }
 
     &.full-height {
-      min-height: calc(100vh - #{$header-height});
+      min-height: 100%;
     }
 
     .expand-button {

--- a/style/seedsource.scss
+++ b/style/seedsource.scss
@@ -544,17 +544,23 @@ tr.visible .visibility-toggle, .visibility-toggle:hover {
   }
 
   .comparisons {
-    height: 60px;
+    min-height: 60px;
+    max-height: 60px;
     background-color: white;
     overflow: hidden;
-    transition: height .5s;
+    transition: min-height .5s;
 
-    &.active {
-      height: 67%;
+    &.preview {
+      min-height: 33%;
+    }
+
+    &.full-height {
+      min-height: calc(100vh - #{$header-height});
     }
 
     .expand-button {
       display: block;
+      position: relative;
       border: 0;
       height: 60px;
       background: linear-gradient($black-bis, $grey-darker);
@@ -569,6 +575,35 @@ tr.visible .visibility-toggle, .visibility-toggle:hover {
       .expand-message {
         font-size: $size-6;
         font-weight: normal;
+      }
+
+      .expand-icons {
+        display: flex;
+        align-items: center;
+        position: absolute;
+        right: 9px;
+        top: 18px;
+
+        .expand-icon {
+          display: inline-block;
+          margin-right: 6px;
+          width: 25px;
+          height: 25px;
+          background: linear-gradient(dimgray 66%, gainsboro 66%, gainsboro 100%);
+          border: 3px solid dimgray;
+
+          &.preview {
+            background: linear-gradient(dimgray 33%, gainsboro 33%, gainsboro 100%);
+          }
+
+          &.full-height {
+            background: gainsboro;
+          }
+
+          &.active {
+            outline: 1px dashed gold;
+          }
+        }
       }
     }
 

--- a/style/seedsource.scss
+++ b/style/seedsource.scss
@@ -578,8 +578,6 @@ tr.visible .visibility-toggle, .visibility-toggle:hover {
       }
 
       .expand-icons {
-        display: flex;
-        align-items: center;
         position: absolute;
         right: 9px;
         top: 18px;


### PR DESCRIPTION
Adds full height to "Compare Seedlots".

`active` is now named `preview`, and it's values switched from `height: 67%` -> `min-height: 33%`. A `height` of `100%` only covers half of the screen, whereas a `min-height` of `100%` covers the whole screen (hence `67%` -> `33%`).

### Pictures:
#### Minimized
<img width="920" alt="image" src="https://user-images.githubusercontent.com/20808982/156820481-c5152638-33fd-4c2f-b942-a2c345c04ec1.png">

#### Preview
(Excuse the MacOS shadowing)
<img width="921" alt="image" src="https://user-images.githubusercontent.com/20808982/156820547-95c8bdbf-de64-4500-85c0-4603e8df5b85.png">

#### Full height
<img width="920" alt="image" src="https://user-images.githubusercontent.com/20808982/156820646-5fc9659a-dc70-4d6c-bf19-6769e265a883.png">
