### PR TITLE
Save versioning

### DIFF
--- a/src/actions/saves.ts
+++ b/src/actions/saves.ts
@@ -1,6 +1,6 @@
 import { get, post, put, ioDelete } from '../io'
 import { setError } from './error'
-import config from '../config'
+import config, { saveVersion } from '../config'
 
 export const SHOW_SAVE_MODAL = 'SHOW_SAVE_MODAL'
 export const HIDE_SAVE_MODAL = 'HIDE_SAVE_MODAL'
@@ -117,6 +117,7 @@ export const createSave = (configuration: any, title: string) => {
   return (dispatch: (event: any) => any) => {
     const data = {
       title,
+      version: saveVersion,
       configuration: JSON.stringify(dumpConfiguration(configuration)),
     }
 
@@ -161,6 +162,7 @@ export const updateSave = (configuration: any, lastSave: any) => {
   return (dispatch: (event: any) => any) => {
     const data = {
       title: lastSave.title,
+      version: saveVersion,
       configuration: JSON.stringify(dumpConfiguration(configuration)),
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -657,3 +657,13 @@ export const regions = [
 ]
 
 export const regionsBoundariesUrl = '/static/geometry/regions.topojson'
+
+export const saveVersion = 2 // Next version should add +1 (must be a larger integer). Also add an entry to `migrations` below.
+
+// `version` is the version you are migrating *from*.
+export const migrations: { version: number; migrate: (configuration: any) => { configuration: any } }[] = [
+  {
+    version: 1,
+    migrate: (configuration: any) => ({ ...configuration, customMode: false }),
+  },
+]

--- a/src/config.ts
+++ b/src/config.ts
@@ -658,7 +658,8 @@ export const regions = [
 
 export const regionsBoundariesUrl = '/static/geometry/regions.topojson'
 
-export const saveVersion = 2 // Next version should add +1 (must be a larger integer). Also add an entry to `migrations` below.
+export const saveVersion = 2 // Next version should add +1 (must be a larger integer). When updating save version,
+// also add to `migrations` below.
 
 // `version` is the version you are migrating *from*.
 export const migrations: { version: number; migrate: (configuration: any) => { configuration: any } }[] = [

--- a/src/containers/SavedRun.tsx
+++ b/src/containers/SavedRun.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import { t, c } from 'ttag'
 import { loadConfiguration, resetConfiguration, deleteSave } from '../actions/saves'
+import { migrateConfiguration } from '../utils'
 
 const connector = connect(null, (dispatch: (event: any) => any, { onClick }: { onClick: () => any }) => {
   return {
@@ -11,11 +12,12 @@ const connector = connect(null, (dispatch: (event: any) => any, { onClick }: { o
 
     onLoad: (save: any) => {
       dispatch(resetConfiguration())
+      const migratedConfiguration = migrateConfiguration(save.configuration, save.version)
 
       /* In some cases where the loaded configuration is similar to the previous one, certain events aren't
        * fired if the event is dispatched in the same event cycle as the reset event
        */
-      setTimeout(() => dispatch(loadConfiguration(save.configuration, save)), 0)
+      setTimeout(() => dispatch(loadConfiguration(migratedConfiguration, save)), 0)
     },
 
     onDelete: (saveId: string) => {

--- a/src/reducers/runConfiguration.ts
+++ b/src/reducers/runConfiguration.ts
@@ -63,15 +63,7 @@ const defaultConfiguration = {
   uploadedPoints: null,
   customLayers: [],
   customMode: false,
-  version: 2, // Next version should be +1 of current version. Add a migration function to `migrations` below.
 }
-
-const migrations: { version: number; migrate: (configuration: any) => { configuration: any } }[] = [
-  {
-    version: 1,
-    migrate: (configuration: any) => ({ ...configuration, customMode: false, version: 2 }),
-  },
-]
 
 export default (state: any = defaultConfiguration, action: any) => {
   const runConfiguration = () => {
@@ -196,18 +188,7 @@ export default (state: any = defaultConfiguration, action: any) => {
         return defaultConfiguration
 
       case LOAD_CONFIGURATION: {
-        const version = action.configuration.version || 1
-        let updatedConfiguration = { ...action.configuration }
-
-        if (version < defaultConfiguration.version) {
-          for (let i = version; i < defaultConfiguration.version; i += 1) {
-            const migration = migrations.find(m => m.version === i)
-            if (migration) {
-              updatedConfiguration = migration.migrate(updatedConfiguration)
-            }
-          }
-        }
-        return { ...defaultConfiguration, ...updatedConfiguration }
+        return { ...defaultConfiguration, ...action.configuration }
       }
 
       case SET_CUSTOM_MODE:

--- a/src/reducers/runConfiguration.ts
+++ b/src/reducers/runConfiguration.ts
@@ -187,9 +187,8 @@ export default (state: any = defaultConfiguration, action: any) => {
       case RESET_CONFIGURATION:
         return defaultConfiguration
 
-      case LOAD_CONFIGURATION: {
+      case LOAD_CONFIGURATION:
         return { ...defaultConfiguration, ...action.configuration }
-      }
 
       case SET_CUSTOM_MODE:
         return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { saveVersion, migrations } from './config'
+
 declare const document: any
 
 export const getLayerUrl = (layer: any, serviceId: string, objective: string, climate: any, region: string) => {
@@ -105,4 +107,18 @@ export const getZoneLabel = (zone?: any) => {
   }
 
   return label
+}
+
+export const migrateConfiguration = (configuration: any, version: number) => {
+  let updatedConfiguration = { ...configuration }
+
+  if (version < saveVersion) {
+    for (let i = version; i < saveVersion; i += 1) {
+      const migration = migrations.find(m => m.version === i)
+      if (migration) {
+        updatedConfiguration = migration.migrate(updatedConfiguration)
+      }
+    }
+  }
+  return updatedConfiguration
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,14 +110,12 @@ export const getZoneLabel = (zone?: any) => {
 }
 
 export const migrateConfiguration = (configuration: any, version: number) => {
-  let updatedConfiguration = { ...configuration }
+  let updatedConfiguration = configuration
 
-  if (version < saveVersion) {
-    for (let i = version; i < saveVersion; i += 1) {
-      const migration = migrations.find(m => m.version === i)
-      if (migration) {
-        updatedConfiguration = migration.migrate(updatedConfiguration)
-      }
+  for (let i = version; i < saveVersion; i += 1) {
+    const migration = migrations.find(m => m.version === i)
+    if (migration) {
+      updatedConfiguration = migration.migrate(updatedConfiguration)
     }
   }
   return updatedConfiguration


### PR DESCRIPTION
Add versioning to saves. A `saveVersion` constant has been added to `src/config.ts`. This is sent on save/update (as `version`) to be stored in the database with each save. [A smaller companion PR of the same name will soon be created for `seedsource-core`, which adds the integer field `version` to the `runconfiguration` model.] When loading a save, before dispatching `loadConfiguration` [since the action `LOAD_CONFIGURATION` is used by several reducers, updates need to occur before dispatch], a save's version is checked against `saveVersion`, and the appropriate migrations in `migrations` are run until the save is up to date. New save versions must be integers higher than their previous version (preferably +1).